### PR TITLE
[Options] Add flexibility on supporting different interaction options

### DIFF
--- a/Sources/BottomSheet/BottomSheetHostingController.swift
+++ b/Sources/BottomSheet/BottomSheetHostingController.swift
@@ -38,7 +38,7 @@ public final class BottomSheetHostingController<Content>: UIHostingController<Co
     public init(
         prefersGrabberVisible: Bool? = nil,
         cornerRadius: CGFloat? = nil,
-        allowsInteractiveDismiss: Bool? = nil,
+        allowedInteractions: SupportedInteractions? = nil,
         rootView: Content
     ) {
         super.init(rootView: rootView)
@@ -52,8 +52,8 @@ public final class BottomSheetHostingController<Content>: UIHostingController<Co
             bottomSheetPresentationController?.cornerRadius = cornerRadius
         }
 
-        if let allowsInteractiveDismiss = allowsInteractiveDismiss {
-            bottomSheetPresentationController?.allowsInteractiveDismiss = allowsInteractiveDismiss
+        if let allowedInteractions = allowedInteractions {
+            bottomSheetPresentationController?.allowedInteractions = allowedInteractions
         }
     }
 

--- a/Sources/BottomSheet/BottomSheetModifier.swift
+++ b/Sources/BottomSheet/BottomSheetModifier.swift
@@ -40,6 +40,7 @@ public extension View {
         isPresented: Binding<Bool>,
         cornerRadius: CGFloat? = nil,
         prefersGrabberVisible: Bool? = nil,
+        allowedInteractions: SupportedInteractions? = .all,
         @ViewBuilder content: @escaping () -> Content
     ) -> some View where Content: View {
         modifier(
@@ -47,6 +48,7 @@ public extension View {
                 isPresented: isPresented,
                 cornerRadius: cornerRadius,
                 prefersGrabberVisible: prefersGrabberVisible,
+                allowedInteractions: allowedInteractions,
                 content: content
             )
         )
@@ -58,17 +60,20 @@ struct BottomSheetModifier<BottomSheet>: ViewModifier where BottomSheet: View {
         isPresented: Binding<Bool>,
         cornerRadius: CGFloat?,
         prefersGrabberVisible: Bool?,
+        allowedInteractions: SupportedInteractions?,
         content: @escaping () -> BottomSheet
     ) {
         _isPresented = isPresented
         self.cornerRadius = cornerRadius
         self.prefersGrabberVisible = prefersGrabberVisible
+        self.allowedInteractions = allowedInteractions
         self.content = content
     }
     
     @Binding var isPresented: Bool
     let cornerRadius: CGFloat?
     let prefersGrabberVisible: Bool?
+    let allowedInteractions: SupportedInteractions?
     let content: () -> BottomSheet
     
     @State private var transitioningDelegate = BottomSheetTransitioningDelegate()
@@ -80,6 +85,7 @@ struct BottomSheetModifier<BottomSheet>: ViewModifier where BottomSheet: View {
                 BottomSheetHostingController(
                     prefersGrabberVisible: prefersGrabberVisible,
                     cornerRadius: cornerRadius,
+                    allowedInteractions: allowedInteractions,
                     rootView: content
                 )
             }

--- a/Sources/BottomSheet/BottomSheetPresentationController.swift
+++ b/Sources/BottomSheet/BottomSheetPresentationController.swift
@@ -66,15 +66,19 @@ final class BottomSheetPresentationController: UIPresentationController {
         }
     }
 
-    public var allowsInteractiveDismiss: Bool = true {
+    public var allowedInteractions: SupportedInteractions = .all {
         didSet {
-            dismissDragGestureRecognizer.isEnabled = allowsInteractiveDismiss
-            dismissTapGestureRecognizer.isEnabled = allowsInteractiveDismiss
+            dismissDragGestureRecognizer.isEnabled = allowedInteractions.contains(.dismissDrag)
+            dismissTapGestureRecognizer.isEnabled = allowedInteractions.contains(.dismissTap)
         }
     }
 
     private let dismissTapGestureRecognizer = UITapGestureRecognizer()
-    let dismissDragGestureRecognizer = UIPanGestureRecognizer()
+    lazy var dismissDragGestureRecognizer: UIPanGestureRecognizer = {
+        let gesture = UIPanGestureRecognizer()
+        gesture.delegate = self
+        return gesture
+    }()
 
 
     override func presentationTransitionWillBegin() {
@@ -203,5 +207,30 @@ final class BottomSheetPresentationController: UIPresentationController {
     private func setDecorations(hidden: Bool) {
         dimmingView.alpha = hidden ? 0 : 1
         grabberView.alpha = hidden || !prefersGrabberVisible ? 0 : 1
+    }
+}
+
+extension BottomSheetPresentationController: UIGestureRecognizerDelegate {
+
+    func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        print("gestureRecognizerShouldBegin")
+        return false
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        print("shouldRecognizeSimultaneouslyWith")
+        print(otherGestureRecognizer)
+        return true
+    }
+
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldReceive event: UIEvent
+    ) -> Bool {
+        print("shouldReceive")
+        return false
     }
 }

--- a/Sources/BottomSheet/SupportedInteractions.swift
+++ b/Sources/BottomSheet/SupportedInteractions.swift
@@ -1,0 +1,41 @@
+//
+//  BottomSheetHostingController.swift
+//
+//  Copyright (c) 2021 @mtzaquia
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in all
+//  copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+//  SOFTWARE.
+//
+
+import Foundation
+
+public struct SupportedInteractions: OptionSet {
+    public enum Interaction: Int {
+        case dismissDrag
+        case dismissTap
+    }
+
+    public let rawValue: Int
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+
+    public static let dismissDrag = SupportedInteractions(rawValue: 1 << Interaction.dismissDrag.rawValue)
+    public static let dismissTap = SupportedInteractions(rawValue: 1 << Interaction.dismissTap.rawValue)
+    public static let all: SupportedInteractions = [.dismissDrag, .dismissTap]
+}


### PR DESCRIPTION
The existing `allowsInteractiveDismiss` was not available for the SwiftUI modifier.
This PR splits the single boolean further and allow SwiftUI to modify the behavior.


https://github.com/mtzaquia/BottomSheet/assets/5168069/98bdc325-0b0a-4d8a-82c7-509894cadf1d

